### PR TITLE
image_limits

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -23,6 +23,9 @@ linter:
   rules:
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    prefer_const_constructors: true
+    prefer_const_literals_to_create_immutables: true
+    prefer_const_declarations: true
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.4.2-rc.05"
+    version: "3.4.2-rc.06"
   cached_network_image:
     dependency: transitive
     description:

--- a/lib/src/image_provider_with_limits.dart
+++ b/lib/src/image_provider_with_limits.dart
@@ -60,7 +60,7 @@ class ImageProviderWithLimits<T extends Object> extends ImageProvider<T> {
   ImageStreamCompleter loadImage(T key, ImageDecoderCallback decode) {
     Future<Codec> wrapper(ImmutableBuffer buffer, {TargetImageSizeCallback? getTargetSize}) async {
       if (buffer.length > imageLimits.limitBytes) {
-        return instantiateImageCodecWithSize(buffer, getTargetSize: (int intrinsicWidth, int intrinsicHeight) {
+        return decode(buffer, getTargetSize: (int intrinsicWidth, int intrinsicHeight) {
           final parentTargetSize = getTargetSize?.call(intrinsicWidth, intrinsicHeight);
 
           int currentTargetWidth = parentTargetSize?.width ?? intrinsicWidth;

--- a/lib/src/image_provider_with_limits.dart
+++ b/lib/src/image_provider_with_limits.dart
@@ -1,25 +1,26 @@
 // Created by alex@justprodev.com on 16.10.2024.
 
 import 'dart:ui';
-
 import 'package:flutter/painting.dart';
 
-extension ImageProviderWithLimitsExt<T extends Object> on ImageProvider<T> {
+extension ImageProviderWithLimitsExt on ImageProvider {
   /// Returns a [ImageProviderWithLimits] that resizes image if needed in accordance with [ImageLimits]
   ///
   /// If [imageLimits] is null, returns the original [ImageProvider]
-  ImageProvider<T> withLimits(ImageLimits? imageLimits) {
+  ImageProvider withLimits(ImageLimits? imageLimits) {
     if (imageLimits == null) return this;
 
-    return ImageProviderWithLimits<T>(this, imageLimits);
+    return ImageProviderWithLimits(this, imageLimits);
   }
 }
 
-/// Settings to reduce memory usage when rendering images.
+/// Settings to reduce the memory footprint of [ImageCache].
+//
+/// If some image file has size > [limitBytes] then image should be resized.
 ///
-/// If some image file has size > [limitBytes] then image should be resized
+/// Value of [targetWidthOrHeight] used depending on which side of image is bigger than [targetWidthOrHeight].
+/// Width should be checked first.
 ///
-/// value of [targetWidthOrHeight] used depending on which side of image is bigger
 ///
 /// Example:
 ///
@@ -39,17 +40,24 @@ class ImageLimits {
     required this.limitBytes,
     required this.targetWidthOrHeight,
   });
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is ImageLimits && other.limitBytes == limitBytes && other.targetWidthOrHeight == targetWidthOrHeight;
+  }
+
+  @override
+  int get hashCode => limitBytes.hashCode ^ targetWidthOrHeight.hashCode;
 }
 
 /// Wrapper over [ImageProvider] that resizes image ONLY if [ImageLimits.limitBytes] is exceeded.
 ///
 /// Otherwise, the process of loading the image will be the same as for the original [ImageProvider].
-///
-/// Note: Because we doing "full delegation", the [ImageCache] will treat this provider as delegated image provider.
-/// This means that object without limits and object with limits will be treated as same objects.
-class ImageProviderWithLimits<T extends Object> extends ImageProvider<T> {
+class ImageProviderWithLimits extends ImageProvider<ImageLimitsKey> {
   final ImageLimits imageLimits;
-  final ImageProvider<T> delegatedImageProvider;
+  final ImageProvider delegatedImageProvider;
 
   const ImageProviderWithLimits(
     this.delegatedImageProvider,
@@ -57,8 +65,8 @@ class ImageProviderWithLimits<T extends Object> extends ImageProvider<T> {
   );
 
   @override
-  ImageStreamCompleter loadImage(T key, ImageDecoderCallback decode) {
-    Future<Codec> wrapper(ImmutableBuffer buffer, {TargetImageSizeCallback? getTargetSize}) async {
+  ImageStreamCompleter loadImage(ImageLimitsKey key, ImageDecoderCallback decode) {
+    Future<Codec> wrapper(ImmutableBuffer buffer, {TargetImageSizeCallback? getTargetSize}) {
       if (buffer.length > imageLimits.limitBytes) {
         return decode(buffer, getTargetSize: (int intrinsicWidth, int intrinsicHeight) {
           final parentTargetSize = getTargetSize?.call(intrinsicWidth, intrinsicHeight);
@@ -80,19 +88,36 @@ class ImageProviderWithLimits<T extends Object> extends ImageProvider<T> {
       return decode(buffer, getTargetSize: getTargetSize);
     }
 
-    return delegatedImageProvider.loadImage(key, wrapper);
+    return delegatedImageProvider.loadImage(key._delegatedProviderKey, wrapper);
   }
 
   @override
-  Future<T> obtainKey(ImageConfiguration configuration) {
-    return delegatedImageProvider.obtainKey(configuration);
+  Future<ImageLimitsKey> obtainKey(ImageConfiguration configuration) {
+    // note [SynchronousFuture.then] will also return a synchronous future.
+    return delegatedImageProvider.obtainKey(configuration).then((key) => ImageLimitsKey._(key, imageLimits));
   }
+}
+
+/// Key used internally by [ImageProviderWithLimits].
+///
+/// This is used to identify the precise resource in the [imageCache].
+///
+/// So, it like [ResizeImageKey]
+class ImageLimitsKey {
+  final Object _delegatedProviderKey;
+  final ImageLimits _imageLimits;
+
+  const ImageLimitsKey._(this._delegatedProviderKey, this._imageLimits);
 
   @override
   bool operator ==(Object other) {
-    return delegatedImageProvider == other;
+    if (identical(this, other)) return true;
+
+    return other is ImageLimitsKey &&
+        other._delegatedProviderKey == _delegatedProviderKey &&
+        other._imageLimits == _imageLimits;
   }
 
   @override
-  int get hashCode => delegatedImageProvider.hashCode;
+  int get hashCode => Object.hash(_delegatedProviderKey, _imageLimits);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cached_image
 description: Convenient wrapper over flutter_cached_network_image with some additional features
 publish_to: none
 
-version: 3.4.2-rc.05
+version: 3.4.2-rc.06
 
 environment:
   sdk: ^3.4.0

--- a/test/image_provider_with_limits_test.dart
+++ b/test/image_provider_with_limits_test.dart
@@ -118,7 +118,7 @@ void main() {
       () async {
         // upscale 1x1 image to 20x20
         final kBigImage = await kTransparentImage.resize(20, 20);
-        final imageLimits = ImageLimits(limitBytes: 0, targetWidthOrHeight: 1);
+        const imageLimits = ImageLimits(limitBytes: 0, targetWidthOrHeight: 1);
 
         final imageProvider = ResizeImage(
           MemoryImage(Uint8List.fromList(kBigImage)),
@@ -139,7 +139,7 @@ void main() {
       () async {
         // upscale 1x1 image to 2x4
         final kTransparentDoubleHeightImage = await kTransparentImage.resize(2, 4);
-        final imageLimits = ImageLimits(limitBytes: 0, targetWidthOrHeight: 2);
+        const imageLimits = ImageLimits(limitBytes: 0, targetWidthOrHeight: 2);
 
         final imageProvider = MemoryImage(Uint8List.fromList(kTransparentDoubleHeightImage)).withLimits(imageLimits);
         final resultImageInfo = await imageProvider.invoke();

--- a/test/image_provider_with_limits_test.dart
+++ b/test/image_provider_with_limits_test.dart
@@ -170,7 +170,7 @@ void main() {
 extension on List<int> {
   Future<List<int>> resize(int targetWidth, [int? targetHeight]) async {
     final pngCodec = await instantiateImageCodec(
-      Uint8List.fromList(kTransparentImage),
+      Uint8List.fromList(this),
       targetWidth: targetWidth,
       targetHeight: targetHeight,
       allowUpscaling: true,


### PR DESCRIPTION
`ImageProviderWithLimits` now cached in  ImageCache under its own key, rather than mimic as delegated provider